### PR TITLE
fix codeql alert

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -2,9 +2,13 @@ name: Build and Lint
 
 on:
   push:
-    branches: [ "main", "slop/pre_build_library" ] # Adjust branches as needed
+    branches: [ "main", "master" ] # Adjust branches as needed
   pull_request:
-    branches: [ "main", "slop/pre_build_library" ] # Adjust branches as needed
+    branches: [ "main", "master" ] # Adjust branches as needed
+
+# Add top-level permissions for least privilege
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
This pull request makes a small but important update to the GitHub Actions workflow configuration file `.github/workflows/build_lint.yml`. It updates the branch names monitored by the workflow and adds permissions for least privilege.

Changes to `.github/workflows/build_lint.yml`:

* Updated the branch names from `"slop/pre_build_library"` to `"master"` for both `push` and `pull_request` triggers.
* Added top-level permissions with `contents: read` to adhere to the principle of least privilege.