### PR TITLE
Slop/simplify

### DIFF
--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -1,3 +1,9 @@
+# See prebuild_dependencies_roadmap.md for the new multi-workflow, multi-arch build strategy.
+# This workflow is now only for linting and sdist build checks. All wheel builds are handled in:
+#   - build_wheels_linux.yml
+#   - build_wheels_macos.yml
+#   - build_wheels_windows.yml (future)
+
 name: Build and Lint
 
 on:
@@ -51,4 +57,4 @@ jobs:
     #   uses: actions/upload-artifact@v4
     #   with:
     #     name: sdist-${{ matrix.python-version }}
-    #     path: dist/*.tar.gz 
+    #     path: dist/*.tar.gz

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,116 +11,116 @@
 #   schedule:
 #     - cron: "0 12 1 * *"
 
-jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }} (${{ matrix.arch || 'native' }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # Define specific combinations for Linux, keep macOS simple
-        include:
-          - os: ubuntu-latest
-            arch: x86_64
-            cibw_archs: "x86_64"
-          - os: ubuntu-22.04-arm
-            arch: aarch64
-            cibw_archs: "aarch64"
-          - os: macos-latest
-            arch: arm64
-            cibw_archs: "arm64"
-          - os: macos-latest
-            arch: x86_64
-            cibw_archs: "x86_64"
-          - os: macos-latest
-            arch: universal2
-            cibw_archs: "universal2"
-          # - os: windows-latest # Add back if/when needed
-          #   arch: AMD64
-          #   cibw_archs: "AMD64"
+# jobs:
+#   build_wheels:
+#     name: Build wheels on ${{ matrix.os }} (${{ matrix.arch || 'native' }})
+#     runs-on: ${{ matrix.os }}
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         # Define specific combinations for Linux, keep macOS simple
+#         include:
+#           - os: ubuntu-latest
+#             arch: x86_64
+#             cibw_archs: "x86_64"
+#           - os: ubuntu-22.04-arm
+#             arch: aarch64
+#             cibw_archs: "aarch64"
+#           - os: macos-latest
+#             arch: arm64
+#             cibw_archs: "arm64"
+#           - os: macos-latest
+#             arch: x86_64
+#             cibw_archs: "x86_64"
+#           - os: macos-latest
+#             arch: universal2
+#             cibw_archs: "universal2"
+#           # - os: windows-latest # Add back if/when needed
+#           #   arch: AMD64
+#           #   cibw_archs: "AMD64"
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: true # Fetch the libpostal submodule
+#     steps:
+#       - name: Checkout repository
+#         uses: actions/checkout@v4
+#         with:
+#           submodules: true # Fetch the libpostal submodule
 
-      # --- QEMU step is removed --- #
+#       # --- QEMU step is removed --- #
 
-      # --- Add steps for caching the compiled libpostal --- #
-      - name: Get libpostal submodule commit hash
-        id: get_submodule_hash
-        # Run in shell that supports pipelines and awk
-        shell: bash 
-        run: |
-          # Need to cd into pypostal if workflow CWD is workspace root
-          # cd pypostal # Remove this line, CWD should be repo root
-          # Extract the commit hash (remove leading +/-, take first field)
-          HASH=$(git submodule status vendor/libpostal | awk '{ sub(/^[+-]?/, ""); print $1 }')
-          echo "hash=$HASH" >> $GITHUB_OUTPUT
+#       # --- Add steps for caching the compiled libpostal --- #
+#       - name: Get libpostal submodule commit hash
+#         id: get_submodule_hash
+#         # Run in shell that supports pipelines and awk
+#         shell: bash 
+#         run: |
+#           # Need to cd into pypostal if workflow CWD is workspace root
+#           # cd pypostal # Remove this line, CWD should be repo root
+#           # Extract the commit hash (remove leading +/-, take first field)
+#           HASH=$(git submodule status vendor/libpostal | awk '{ sub(/^[+-]?/, ""); print $1 }')
+#           echo "hash=$HASH" >> $GITHUB_OUTPUT
 
-      - name: Cache compiled libpostal library
-        uses: actions/cache@v4
-        with:
-          # Cache the directory containing arch-specific builds
-          # Path is relative to the repository root where setup.py runs
-          path: build/libpostal_install_cache
-          # Key includes OS, architecture, and the submodule hash
-          key: ${{ matrix.os }}-${{ matrix.arch }}-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
-          # Restore key prefix in case of exact miss
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.arch }}-libpostal-cache-
-      # -------------------------------------------------- #
+#       - name: Cache compiled libpostal library
+#         uses: actions/cache@v4
+#         with:
+#           # Cache the directory containing arch-specific builds
+#           # Path is relative to the repository root where setup.py runs
+#           path: build/libpostal_install_cache
+#           # Key includes OS, architecture, and the submodule hash
+#           key: ${{ matrix.os }}-${{ matrix.arch }}-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+#           # Restore key prefix in case of exact miss
+#           restore-keys: |
+#             ${{ matrix.os }}-${{ matrix.arch }}-libpostal-cache-
+#       # -------------------------------------------------- #
       
-      # Ensure the base directory for the cache exists before cibuildwheel runs
-      - name: Ensure cache directory exists
-        shell: bash # Use bash for consistency across runners
-        run: mkdir -p build/libpostal_install_cache
+#       # Ensure the base directory for the cache exists before cibuildwheel runs
+#       - name: Ensure cache directory exists
+#         shell: bash # Use bash for consistency across runners
+#         run: mkdir -p build/libpostal_install_cache
 
-      # Windows Specific Setup: Install MSYS2 and required tools
-      # Note: This step will only run if/when windows-latest is added back to the matrix
-      - name: Set up MSYS2 (Windows)
-        if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: MINGW64 # Or other environments like MSYS if needed
-          update: true
-          install: >- # Using multiline string for clarity
-            mingw-w64-x86_64-toolchain
-            autoconf
-            automake
-            libtool
-            pkg-config
-            curl
-            make 
-          # Note: automake-wrapper is often needed on MSYS2
+#       # Windows Specific Setup: Install MSYS2 and required tools
+#       # Note: This step will only run if/when windows-latest is added back to the matrix
+#       - name: Set up MSYS2 (Windows)
+#         if: runner.os == 'Windows'
+#         uses: msys2/setup-msys2@v2
+#         with:
+#           msystem: MINGW64 # Or other environments like MSYS if needed
+#           update: true
+#           install: >- # Using multiline string for clarity
+#             mingw-w64-x86_64-toolchain
+#             autoconf
+#             automake
+#             libtool
+#             pkg-config
+#             curl
+#             make 
+#           # Note: automake-wrapper is often needed on MSYS2
 
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.17.0 # Use a recent version
-        env:
-          # Only build for the two latest CPython versions (3.11 and 3.12)
-          CIBW_BUILD: "cp311-* cp312-*"
-          # Configure CIBW_BEFORE_BUILD_* for platform-specific dependency installation
-          CIBW_BEFORE_BUILD_LINUX: "dnf install -y autoconf automake libtool pkgconfig curl perl-IPC-Cmd"
-          CIBW_BEFORE_BUILD_MACOS: "brew install autoconf automake libtool pkg-config curl"
-          CIBW_BEFORE_BUILD_WINDOWS: ""
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
-          CIBW_ENVIRONMENT_WINDOWS: >
-            PATH="C:\Windows\System32;C:\msys64\usr\bin;C:\msys64\mingw64\bin;{env_path}"
-          CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
-          CIBW_BUILD_VERBOSITY: "1"
-          CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
-        with:
-          # Output directory for wheels
-          output-dir: wheelhouse
-          # Specify packages to build if pyproject.toml is not in root
-          # package-dir: . # Assumes setup.py is in the root of pypostal
+#       - name: Build wheels
+#         uses: pypa/cibuildwheel@v2.17.0 # Use a recent version
+#         env:
+#           # Only build for the two latest CPython versions (3.11 and 3.12)
+#           CIBW_BUILD: "cp311-* cp312-*"
+#           # Configure CIBW_BEFORE_BUILD_* for platform-specific dependency installation
+#           CIBW_BEFORE_BUILD_LINUX: "dnf install -y autoconf automake libtool pkgconfig curl perl-IPC-Cmd"
+#           CIBW_BEFORE_BUILD_MACOS: "brew install autoconf automake libtool pkg-config curl"
+#           CIBW_BEFORE_BUILD_WINDOWS: ""
+#           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+#           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+#           CIBW_ENVIRONMENT_WINDOWS: >
+#             PATH="C:\Windows\System32;C:\msys64\usr\bin;C:\msys64\mingw64\bin;{env_path}"
+#           CIBW_ARCHS: ${{ matrix.cibw_archs }}
+#           CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
+#           CIBW_BUILD_VERBOSITY: "1"
+#           CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
+#         with:
+#           # Output directory for wheels
+#           output-dir: wheelhouse
+#           # Specify packages to build if pyproject.toml is not in root
+#           # package-dir: . # Assumes setup.py is in the root of pypostal
 
-      - name: Upload wheels
-        uses: actions/upload-artifact@v4
-        with:
-          # Include OS and Arch in artifact name for clarity
-          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
-          path: ./wheelhouse/*.whl
+#       - name: Upload wheels
+#         uses: actions/upload-artifact@v4
+#         with:
+#           # Include OS and Arch in artifact name for clarity
+#           name: wheels-${{ matrix.os }}-${{ matrix.arch }}
+#           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -92,43 +92,20 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17.0 # Use a recent version
         env:
+          # Only build for the two latest CPython versions (3.11 and 3.12)
+          CIBW_BUILD: "cp311-* cp312-*"
           # Configure CIBW_BEFORE_BUILD_* for platform-specific dependency installation
-          # Linux (manylinux): Use dnf (runs inside manylinux_2_28 container)
-          # Note: Needs to run on both x86_64 and native arm64 runners now
           CIBW_BEFORE_BUILD_LINUX: "dnf install -y autoconf automake libtool pkgconfig curl perl-IPC-Cmd"
-          
-          # macOS: Use brew
           CIBW_BEFORE_BUILD_MACOS: "brew install autoconf automake libtool pkg-config curl"
-          
-          # Windows: Dependencies installed via msys2/setup-msys2 action above. 
-          CIBW_BEFORE_BUILD_WINDOWS: "" # Dependencies installed in previous step if Windows is enabled
-
-          # --- Use manylinux_2_28 images --- #
+          CIBW_BEFORE_BUILD_WINDOWS: ""
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
-          # CIBW_MANYLINUX_I686_IMAGE: manylinux_2_28 # Uncomment if building i686
-          # CIBW_MANYLINUX_PPC64LE_IMAGE: manylinux_2_28 # Uncomment if building ppc64le
-          # CIBW_MANYLINUX_S390X_IMAGE: manylinux_2_28 # Uncomment if building s390x
-
-          # --- Set PATH for Windows builds (only relevant if Windows matrix entry exists) --- #
           CIBW_ENVIRONMENT_WINDOWS: >
             PATH="C:\Windows\System32;C:\msys64\usr\bin;C:\msys64\mingw64\bin;{env_path}"
-
-          # --- Specify Architectures based on matrix --- #
-          # On Linux/Windows, we use the specific arch from the matrix.
-          # On macOS, 'auto' lets cibuildwheel build both x86_64 and arm64.
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-
-          # Skip PyPy, musllinux, and Python 3.7 on Windows (only relevant if Windows matrix entry exists)
           CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
-          
-          # Increase build verbosity - Corrected escaping
           CIBW_BUILD_VERBOSITY: "1"
-
-          # Test command: Basic import after install - Corrected escaping
           CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
-          # NOTE: Full functionality test requires data download (Phase 3)
-          
         with:
           # Output directory for wheels
           output-dir: wheelhouse
@@ -140,4 +117,4 @@ jobs:
         with:
           # Include OS and Arch in artifact name for clarity
           name: wheels-${{ matrix.os }}-${{ matrix.arch }}
-          path: ./wheelhouse/*.whl 
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,16 +1,16 @@
-name: Build Wheels
+# DISABLED: This workflow is now superseded by build_wheels_linux.yml and build_wheels_macos.yml.
+# To re-enable, restore the 'on:' section below.
+# on:
+#   push:
+#     branches: [ "main", "master"]
+#     tags:
+#       - 'v*'
+#   pull_request:
+#     branches: [ "main", "master" ]
+#   workflow_dispatch:
+#   schedule:
+#     - cron: "0 12 1 * *"
 
-on:
-  push:
-    branches: [ "main", "master"] # Adjust branches as needed
-    tags:
-      - 'v*'
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main", "master" ]
-  workflow_dispatch: # Allow manual trigger
-  schedule:
-    - cron: "0 12 1 * *" # Run monthly on the 1st at 12:00 UTC
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }} (${{ matrix.arch || 'native' }})

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,15 +20,21 @@ jobs:
       matrix:
         # Define specific combinations for Linux, keep macOS simple
         include:
-          - os: ubuntu-latest # Standard x86_64 runner
+          - os: ubuntu-latest
             arch: x86_64
             cibw_archs: "x86_64"
-          - os: ubuntu-22.04-arm # Native ARM64 runner
+          - os: ubuntu-22.04-arm
             arch: aarch64
             cibw_archs: "aarch64"
-          - os: macos-latest # Builds both x86_64 and arm64 via cibuildwheel default
-            arch: universal
-            cibw_archs: "auto" # Let cibuildwheel handle macOS archs
+          - os: macos-latest
+            arch: arm64
+            cibw_archs: "arm64"
+          - os: macos-latest
+            arch: x86_64
+            cibw_archs: "x86_64"
+          - os: macos-latest
+            arch: universal2
+            cibw_archs: "universal2"
           # - os: windows-latest # Add back if/when needed
           #   arch: AMD64
           #   cibw_archs: "AMD64"

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -38,16 +38,6 @@ jobs:
           HASH=$(git submodule status vendor/libpostal | awk '{ sub(/^[+-]?/, ""); print $1 }')
           echo "hash=$HASH" >> $GITHUB_OUTPUT
 
-      - name: Cache compiled libpostal library
-        uses: actions/cache@v4
-        with:
-          # Just specify the base directory - setup.py will create architecture-specific subdirectories
-          path: build/libpostal_install_cache
-          # Use a versioned cache key to allow for cache invalidation when build logic changes
-          key: linux-${{ matrix.arch }}-libpostal-cache-v2-${{ steps.get_submodule_hash.outputs.hash }}
-          restore-keys: |
-            linux-${{ matrix.arch }}-libpostal-cache-v2-
-
       - name: Ensure cache directory exists
         shell: bash
         run: |
@@ -72,8 +62,31 @@ jobs:
           CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
           CIBW_BUILD_VERBOSITY: "1"
           CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
+          # Add special environment variable to track the host and container paths
+          CIBW_ENVIRONMENT: "LIBPOSTAL_HOST_CACHE_DIR=$(pwd)/build/libpostal_install_cache"
+          # This command runs after each wheel is built to copy the compiled libraries back to the host
+          CIBW_AFTER_BUILD: |
+            python -c "import os; import shutil; import glob; src=os.path.join('build', 'libpostal_install_cache'); dest=os.environ.get('LIBPOSTAL_HOST_CACHE_DIR', src); print(f'Copying {src} to {dest}'); [shutil.copytree(d, os.path.join(dest, os.path.basename(d)), dirs_exist_ok=True) for d in glob.glob(os.path.join(src, '*'))]"
         with:
           output-dir: wheelhouse
+
+      - name: Verify cache contents after build
+        run: |
+          echo "=== Cache directory structure after build ==="
+          find build/libpostal_install_cache -type d | sort
+          echo "=== Cache file sizes after build ==="
+          find build/libpostal_install_cache -type f -name "*.a" -exec ls -lh {} \; || echo "No .a files found"
+          du -sh build/libpostal_install_cache/*
+
+      - name: Cache compiled libpostal library
+        uses: actions/cache@v4
+        with:
+          # Just specify the base directory - setup.py will create architecture-specific subdirectories
+          path: build/libpostal_install_cache
+          # Use a versioned cache key to allow for cache invalidation when build logic changes
+          key: linux-${{ matrix.arch }}-libpostal-cache-v2-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            linux-${{ matrix.arch }}-libpostal-cache-v2-
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -50,6 +50,14 @@ jobs:
         shell: bash
         run: mkdir -p build/libpostal_install_cache
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Upgrade pip and install cibuildwheel
+        run: python -m pip install --upgrade pip cibuildwheel
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17.0
         env:

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -1,0 +1,71 @@
+name: Build Wheels (Linux)
+
+on:
+  push:
+    branches: [ "main", "master" ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ "main", "master" ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 1 * *"
+
+jobs:
+  build_wheels_linux:
+    name: Build wheels on Linux (${{ matrix.arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+            cibw_archs: "x86_64"
+          - os: ubuntu-22.04-arm
+            arch: aarch64
+            cibw_archs: "aarch64"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Get libpostal submodule commit hash
+        id: get_submodule_hash
+        shell: bash
+        run: |
+          HASH=$(git submodule status vendor/libpostal | awk '{ sub(/^[+-]?/, ""); print $1 }')
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+
+      - name: Cache compiled libpostal library
+        uses: actions/cache@v4
+        with:
+          path: build/libpostal_install_cache
+          key: linux-${{ matrix.arch }}-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            linux-${{ matrix.arch }}-libpostal-cache-
+
+      - name: Ensure cache directory exists
+        shell: bash
+        run: mkdir -p build/libpostal_install_cache
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.17.0
+        env:
+          CIBW_BUILD: "cp311-* cp312-*"
+          CIBW_BEFORE_BUILD_LINUX: "dnf install -y autoconf automake libtool pkgconfig curl perl-IPC-Cmd"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
+          CIBW_BUILD_VERBOSITY: "1"
+          CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
+        with:
+          output-dir: wheelhouse
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.arch }}
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -41,14 +41,17 @@ jobs:
       - name: Cache compiled libpostal library
         uses: actions/cache@v4
         with:
+          # Just specify the base directory - setup.py will create architecture-specific subdirectories
           path: build/libpostal_install_cache
-          key: linux-${{ matrix.arch }}-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          # Use a versioned cache key to allow for cache invalidation when build logic changes
+          key: linux-${{ matrix.arch }}-libpostal-cache-v2-${{ steps.get_submodule_hash.outputs.hash }}
           restore-keys: |
-            linux-${{ matrix.arch }}-libpostal-cache-
+            linux-${{ matrix.arch }}-libpostal-cache-v2-
 
       - name: Ensure cache directory exists
         shell: bash
-        run: mkdir -p build/libpostal_install_cache
+        run: |
+          mkdir -p build/libpostal_install_cache
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/build_wheels_linux.yml
+++ b/.github/workflows/build_wheels_linux.yml
@@ -38,10 +38,14 @@ jobs:
           HASH=$(git submodule status vendor/libpostal | awk '{ sub(/^[+-]?/, ""); print $1 }')
           echo "hash=$HASH" >> $GITHUB_OUTPUT
 
-      - name: Ensure cache directory exists
-        shell: bash
-        run: |
-          mkdir -p build/libpostal_install_cache
+      - name: Cache compiled libpostal library
+        uses: actions/cache@v4
+        id: cache-libpostal
+        with:
+          path: build/libpostal_install_cache
+          key: linux-${{ matrix.arch }}-libpostal-cache-v2-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            linux-${{ matrix.arch }}-libpostal-cache-v2-
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -50,6 +54,39 @@ jobs:
 
       - name: Upgrade pip and install cibuildwheel
         run: python -m pip install --upgrade pip cibuildwheel
+
+      # Create an explicit bash script to execute inside the container
+      - name: Create copy script
+        run: |
+          cat > copy_cache.sh << 'EOF'
+          #!/bin/bash
+          set -ex
+          
+          # Print build directory content for debugging
+          echo "Container build directory content:"
+          ls -la build/ || echo "No build directory"
+          
+          CACHE_DIR="build/libpostal_install_cache"
+          if [ -d "$CACHE_DIR" ]; then
+            echo "Found cache directory at $CACHE_DIR"
+            mkdir -p "/host$CACHE_DIR"
+            ls -la "$CACHE_DIR" || echo "Empty cache directory"
+            find "$CACHE_DIR" -type d -exec ls -la {} \; || echo "No directories found"
+            
+            # Copy all files, creating directories as needed
+            cp -r "$CACHE_DIR"/* "/host$CACHE_DIR/" || echo "Copy failed"
+            
+            echo "After copy to host:"
+            ls -la "/host$CACHE_DIR/" || echo "Empty host cache directory"
+          else
+            echo "Cache directory $CACHE_DIR not found"
+          fi
+          EOF
+          chmod +x copy_cache.sh
+
+      - name: Ensure cache directory exists
+        shell: bash
+        run: mkdir -p build/libpostal_install_cache
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.17.0
@@ -62,11 +99,9 @@ jobs:
           CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
           CIBW_BUILD_VERBOSITY: "1"
           CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
-          # Add special environment variable to track the host and container paths
-          CIBW_ENVIRONMENT: "LIBPOSTAL_HOST_CACHE_DIR=$(pwd)/build/libpostal_install_cache"
-          # This command runs after each wheel is built to copy the compiled libraries back to the host
+          # Improved after-build step that calls our dedicated script
           CIBW_AFTER_BUILD: |
-            python -c "import os; import shutil; import glob; src=os.path.join('build', 'libpostal_install_cache'); dest=os.environ.get('LIBPOSTAL_HOST_CACHE_DIR', src); print(f'Copying {src} to {dest}'); [shutil.copytree(d, os.path.join(dest, os.path.basename(d)), dirs_exist_ok=True) for d in glob.glob(os.path.join(src, '*'))]"
+            /host/copy_cache.sh
         with:
           output-dir: wheelhouse
 
@@ -76,17 +111,7 @@ jobs:
           find build/libpostal_install_cache -type d | sort
           echo "=== Cache file sizes after build ==="
           find build/libpostal_install_cache -type f -name "*.a" -exec ls -lh {} \; || echo "No .a files found"
-          du -sh build/libpostal_install_cache/*
-
-      - name: Cache compiled libpostal library
-        uses: actions/cache@v4
-        with:
-          # Just specify the base directory - setup.py will create architecture-specific subdirectories
-          path: build/libpostal_install_cache
-          # Use a versioned cache key to allow for cache invalidation when build logic changes
-          key: linux-${{ matrix.arch }}-libpostal-cache-v2-${{ steps.get_submodule_hash.outputs.hash }}
-          restore-keys: |
-            linux-${{ matrix.arch }}-libpostal-cache-v2-
+          du -sh build/libpostal_install_cache/* || echo "No subdirectories found"
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -28,6 +28,14 @@ jobs:
           HASH=$(git submodule status vendor/libpostal | awk '{ sub(/^[+-]?/, ""); print $1 }')
           echo "hash=$HASH" >> $GITHUB_OUTPUT
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Upgrade pip and install cibuildwheel
+        run: python -m pip install --upgrade pip cibuildwheel
+
       # --- arm64 ---
       - name: Restore arm64 cache
         uses: actions/cache@v4

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -1,0 +1,110 @@
+name: Build Wheels (macOS)
+
+on:
+  push:
+    branches: [ "main", "master" ]
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [ "main", "master" ]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 12 1 * *"
+
+jobs:
+  build_wheels_macos:
+    name: Build wheels on macOS (arm64, x86_64, universal2)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Get libpostal submodule commit hash
+        id: get_submodule_hash
+        shell: bash
+        run: |
+          HASH=$(git submodule status vendor/libpostal | awk '{ sub(/^[+-]?/, ""); print $1 }')
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+
+      # --- arm64 ---
+      - name: Restore arm64 cache
+        uses: actions/cache@v4
+        with:
+          path: build/libpostal_install_cache
+          key: macos-arm64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            macos-arm64-libpostal-cache-
+      - name: Build arm64 wheels
+        run: |
+          export CIBW_ARCHS=arm64
+          cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp311-* cp312-*"
+          CIBW_BEFORE_BUILD_MACOS: "brew install autoconf automake libtool pkg-config curl"
+          CIBW_ARCHS: arm64
+          CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
+          CIBW_BUILD_VERBOSITY: "1"
+          CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
+      - name: Save arm64 cache
+        uses: actions/cache@v4
+        with:
+          path: build/libpostal_install_cache
+          key: macos-arm64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+
+      # --- x86_64 ---
+      - name: Restore x86_64 cache
+        uses: actions/cache@v4
+        with:
+          path: build/libpostal_install_cache
+          key: macos-x86_64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            macos-x86_64-libpostal-cache-
+      - name: Build x86_64 wheels
+        run: |
+          export CIBW_ARCHS=x86_64
+          cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp311-* cp312-*"
+          CIBW_BEFORE_BUILD_MACOS: "brew install autoconf automake libtool pkg-config curl"
+          CIBW_ARCHS: x86_64
+          CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
+          CIBW_BUILD_VERBOSITY: "1"
+          CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
+      - name: Save x86_64 cache
+        uses: actions/cache@v4
+        with:
+          path: build/libpostal_install_cache
+          key: macos-x86_64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+
+      # --- universal2 ---
+      - name: Restore universal2 cache
+        uses: actions/cache@v4
+        with:
+          path: build/libpostal_install_cache
+          key: macos-universal2-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            macos-universal2-libpostal-cache-
+      - name: Build universal2 wheels
+        run: |
+          export CIBW_ARCHS=universal2
+          cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp311-* cp312-*"
+          CIBW_BEFORE_BUILD_MACOS: "brew install autoconf automake libtool pkg-config curl"
+          CIBW_ARCHS: universal2
+          CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
+          CIBW_BUILD_VERBOSITY: "1"
+          CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
+      - name: Save universal2 cache
+        uses: actions/cache@v4
+        with:
+          path: build/libpostal_install_cache
+          key: macos-universal2-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-all
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels_macos.yml
+++ b/.github/workflows/build_wheels_macos.yml
@@ -14,7 +14,8 @@ on:
 jobs:
   build_wheels_macos:
     name: Build wheels on macOS (arm64, x86_64, universal2)
-    runs-on: macos-latest
+    # Use macOS-14 (ARM64) runner which can test both ARM64 and x86_64 via Rosetta 2
+    runs-on: macos-14
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -36,14 +37,21 @@ jobs:
       - name: Upgrade pip and install cibuildwheel
         run: python -m pip install --upgrade pip cibuildwheel
 
-      # --- arm64 ---
-      - name: Restore arm64 cache
+      # Ensure the base cache directory exists
+      - name: Create cache directory structure
+        run: mkdir -p build/libpostal_install_cache
+
+      # --- Restore a single shared cache for all architectures ---
+      - name: Cache libpostal libraries
         uses: actions/cache@v4
+        id: cache-macos
         with:
           path: build/libpostal_install_cache
-          key: macos-arm64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          key: macos-all-libpostal-cache-v2-${{ steps.get_submodule_hash.outputs.hash }}
           restore-keys: |
-            macos-arm64-libpostal-cache-
+            macos-all-libpostal-cache-v2-
+
+      # --- arm64 ---
       - name: Build arm64 wheels
         run: |
           export CIBW_ARCHS=arm64
@@ -55,20 +63,8 @@ jobs:
           CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
           CIBW_BUILD_VERBOSITY: "1"
           CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
-      - name: Save arm64 cache
-        uses: actions/cache@v4
-        with:
-          path: build/libpostal_install_cache
-          key: macos-arm64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
 
       # --- x86_64 ---
-      - name: Restore x86_64 cache
-        uses: actions/cache@v4
-        with:
-          path: build/libpostal_install_cache
-          key: macos-x86_64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
-          restore-keys: |
-            macos-x86_64-libpostal-cache-
       - name: Build x86_64 wheels
         run: |
           export CIBW_ARCHS=x86_64
@@ -80,20 +76,8 @@ jobs:
           CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
           CIBW_BUILD_VERBOSITY: "1"
           CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
-      - name: Save x86_64 cache
-        uses: actions/cache@v4
-        with:
-          path: build/libpostal_install_cache
-          key: macos-x86_64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
 
       # --- universal2 ---
-      - name: Restore universal2 cache
-        uses: actions/cache@v4
-        with:
-          path: build/libpostal_install_cache
-          key: macos-universal2-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
-          restore-keys: |
-            macos-universal2-libpostal-cache-
       - name: Build universal2 wheels
         run: |
           export CIBW_ARCHS=universal2
@@ -105,11 +89,14 @@ jobs:
           CIBW_SKIP: "pp* *-musllinux_* cp37-win*"
           CIBW_BUILD_VERBOSITY: "1"
           CIBW_TEST_COMMAND: "python -c \"import os; print('Testing postal import...'); import postal; print(f'postal imported successfully. __file__={postal.__file__}')\""
-      - name: Save universal2 cache
+
+      # --- Save the single shared cache ---
+      - name: Save cache
         uses: actions/cache@v4
+        if: always()
         with:
           path: build/libpostal_install_cache
-          key: macos-universal2-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          key: macos-all-libpostal-cache-v2-${{ steps.get_submodule_hash.outputs.hash }}
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/diagnose_caches.yml
+++ b/.github/workflows/diagnose_caches.yml
@@ -1,0 +1,150 @@
+name: Diagnose Cache Contents
+
+on:
+  workflow_dispatch:  # Allow manual triggering
+  
+jobs:
+  diagnose-macos-caches:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Get libpostal submodule commit hash
+        id: get_submodule_hash
+        run: |
+          HASH=$(git submodule status vendor/libpostal | awk '{ sub(/^[+-]?/, ""); print $1 }')
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+      
+      # Restore all three Mac caches
+      - name: Restore arm64 cache
+        uses: actions/cache@v4
+        id: cache-arm64
+        with:
+          path: build/libpostal_install_cache/macos-arm64-libpostal-${{ steps.get_submodule_hash.outputs.hash }}
+          key: macos-arm64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            macos-arm64-libpostal-cache-
+      
+      - name: Examine arm64 cache
+        if: steps.cache-arm64.outputs.cache-hit == 'true'
+        run: |
+          echo "===== ARM64 CACHE CONTENTS ====="
+          du -sh build/libpostal_install_cache/macos-arm64-libpostal-${{ steps.get_submodule_hash.outputs.hash }}
+          find build/libpostal_install_cache/macos-arm64-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type f -name "*.a" -exec ls -lh {} \;
+          find build/libpostal_install_cache/macos-arm64-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type f -name "*.h" | wc -l
+          find build/libpostal_install_cache/macos-arm64-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type d | sort
+          echo "================================="
+      
+      - name: Restore x86_64 cache
+        uses: actions/cache@v4
+        id: cache-x86_64
+        with:
+          path: build/libpostal_install_cache/macos-x86_64-libpostal-${{ steps.get_submodule_hash.outputs.hash }}
+          key: macos-x86_64-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            macos-x86_64-libpostal-cache-
+      
+      - name: Examine x86_64 cache
+        if: steps.cache-x86_64.outputs.cache-hit == 'true'
+        run: |
+          echo "===== X86_64 CACHE CONTENTS ====="
+          du -sh build/libpostal_install_cache/macos-x86_64-libpostal-${{ steps.get_submodule_hash.outputs.hash }}
+          find build/libpostal_install_cache/macos-x86_64-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type f -name "*.a" -exec ls -lh {} \;
+          find build/libpostal_install_cache/macos-x86_64-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type f -name "*.h" | wc -l
+          find build/libpostal_install_cache/macos-x86_64-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type d | sort
+          echo "=================================="
+      
+      - name: Restore universal2 cache
+        uses: actions/cache@v4
+        id: cache-universal2
+        with:
+          path: build/libpostal_install_cache/macos-universal2-libpostal-${{ steps.get_submodule_hash.outputs.hash }}
+          key: macos-universal2-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            macos-universal2-libpostal-cache-
+      
+      - name: Examine universal2 cache
+        if: steps.cache-universal2.outputs.cache-hit == 'true'
+        run: |
+          echo "===== UNIVERSAL2 CACHE CONTENTS ====="
+          du -sh build/libpostal_install_cache/macos-universal2-libpostal-${{ steps.get_submodule_hash.outputs.hash }}
+          find build/libpostal_install_cache/macos-universal2-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type f -name "*.a" -exec ls -lh {} \;
+          find build/libpostal_install_cache/macos-universal2-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type f -name "*.h" | wc -l
+          find build/libpostal_install_cache/macos-universal2-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type d | sort
+          echo "======================================"
+      
+      - name: Check architecture of libpostal.a
+        if: steps.cache-universal2.outputs.cache-hit == 'true' || steps.cache-x86_64.outputs.cache-hit == 'true' || steps.cache-arm64.outputs.cache-hit == 'true'
+        run: |
+          echo "===== CHECKING ARCHITECTURES ====="
+          for LIB in $(find build/libpostal_install_cache -name "libpostal.a"); do
+            echo "Architecture of $LIB:"
+            lipo -info $LIB
+          done
+          echo "================================"
+
+  diagnose-linux-caches:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Get libpostal submodule commit hash
+        id: get_submodule_hash
+        run: |
+          HASH=$(git submodule status vendor/libpostal | awk '{ sub(/^[+-]?/, ""); print $1 }')
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+      
+      - name: Create cache directory
+        run: |
+          mkdir -p build/libpostal_install_cache/linux-${{ matrix.arch }}-libpostal-${{ steps.get_submodule_hash.outputs.hash }}
+      
+      - name: Restore Linux cache
+        uses: actions/cache@v4
+        id: cache-linux
+        with:
+          path: build/libpostal_install_cache/linux-${{ matrix.arch }}-libpostal-${{ steps.get_submodule_hash.outputs.hash }}
+          key: linux-${{ matrix.arch }}-libpostal-cache-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            linux-${{ matrix.arch }}-libpostal-cache-
+      
+      - name: Examine Linux cache
+        if: steps.cache-linux.outputs.cache-hit == 'true'
+        run: |
+          echo "===== LINUX ${{ matrix.arch }} CACHE CONTENTS ====="
+          du -sh build/libpostal_install_cache/linux-${{ matrix.arch }}-libpostal-${{ steps.get_submodule_hash.outputs.hash }}
+          find build/libpostal_install_cache/linux-${{ matrix.arch }}-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type f | wc -l
+          find build/libpostal_install_cache/linux-${{ matrix.arch }}-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type f | xargs -I{} ls -lh {} || echo "No files found"
+          find build/libpostal_install_cache/linux-${{ matrix.arch }}-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type d | sort
+          echo "==========================================="
+      
+      # Create test file in a SEPARATE diagnostic directory to avoid interfering with real caches
+      - name: Create test file in diagnostic directory if cache is empty
+        if: steps.cache-linux.outputs.cache-hit == 'true'
+        run: |
+          FILE_COUNT=$(find build/libpostal_install_cache/linux-${{ matrix.arch }}-libpostal-${{ steps.get_submodule_hash.outputs.hash }} -type f | wc -l)
+          mkdir -p build/diagnostic_cache/${{ matrix.arch }}
+          if [ "$FILE_COUNT" -eq "0" ]; then
+            echo "Cache appears empty, creating diagnostic file..."
+            echo "This is a test file created to verify cache writing works" > build/diagnostic_cache/${{ matrix.arch }}/test_file.txt
+          else
+            echo "Cache has $FILE_COUNT files. Creating summary file in diagnostic directory."
+            echo "Found $FILE_COUNT files in the cache" > build/diagnostic_cache/${{ matrix.arch }}/summary.txt
+          fi
+      
+      # Save diagnostic data with a completely different prefix to avoid any chance of conflict
+      - name: Save diagnostic info
+        uses: actions/cache@v4
+        with:
+          path: build/diagnostic_cache/${{ matrix.arch }}
+          key: diagnostic-only-linux-${{ matrix.arch }}-${{ steps.get_submodule_hash.outputs.hash }}
+          restore-keys: |
+            diagnostic-only-linux-${{ matrix.arch }}-

--- a/setup.py
+++ b/setup.py
@@ -95,15 +95,17 @@ def get_build_env():
 # Custom build_ext command
 class build_ext(_build_ext):
     def clean_libpostal_build_dir(self):
-        print("[pypostal] Cleaning libpostal build directory with 'make clean' and 'git clean -xfd'...", flush=True)
-        try:
-            subprocess.check_call(['make', 'clean'], cwd=vendor_dir)
-        except Exception as e:
-            print(f"[pypostal] Warning: 'make clean' failed: {e}", flush=True)
-        try:
-            subprocess.check_call(['git', 'clean', '-xfd'], cwd=vendor_dir)
-        except Exception as e:
-            print(f"[pypostal] Warning: 'git clean -xfd' failed: {e}", flush=True)
+        print("[pypostal] Relaxed cleaning: only running 'make clean' if Makefile exists, and skipping 'git clean -xfd' to avoid deleting build scripts.", flush=True)
+        makefile_path = os.path.join(vendor_dir, 'Makefile')
+        if os.path.exists(makefile_path):
+            try:
+                subprocess.check_call(['make', 'clean'], cwd=vendor_dir)
+            except Exception as e:
+                print(f"[pypostal] Warning: 'make clean' failed: {e}", flush=True)
+        else:
+            print("[pypostal] Skipping 'make clean': Makefile not found.", flush=True)
+        # No longer running 'git clean -xfd' to avoid deleting important build/configure scripts
+        # If you want to clean build artifacts, do so more selectively here.
 
     def run(self):
         cache_base_dir = get_cache_dir()

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,12 @@ def get_cache_dir():
     os_name = get_os_name()
     arch = normalize_arch(os.environ.get('CIBW_ARCHS', platform.machine()))
     commit = get_libpostal_commit()
-    return os.path.abspath(os.path.join('build', f'libpostal_install_cache/{os_name}-{arch}-libpostal-{commit}'))
+    
+    # Use a unique subdirectory for each architecture
+    # This ensures each arch build goes to a separate directory
+    # and prevents sequential builds from overwriting each other
+    base_dir = os.path.abspath(os.path.join('build', 'libpostal_install_cache'))
+    return os.path.join(base_dir, f'{os_name}-{arch}-libpostal-{commit}')
 
 def get_build_env():
     """Return a dict of environment variables for building libpostal, standardized across OSes."""


### PR DESCRIPTION
This pull request introduces significant updates to the build process for the `pypostal` project, focusing on improving compatibility, standardizing architecture handling, and enhancing diagnostics. The changes include updates to the `setup.py` file for better architecture normalization, new helper functions for build environment configuration, and support for building universal2 binaries on macOS. Additionally, the CI workflow has been streamlined to target only the latest Python versions.

### Build process improvements:

* **Architecture normalization and build environment setup:**
  - Added helper functions such as `normalize_arch`, `get_os_name`, and `get_build_env` to standardize architecture detection and configure platform-specific build environments. (`setup.py`, [setup.pyR22-R105](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R22-R105))
  - Updated the `run` method in `build_ext` to use these helper functions for determining cache directories and build paths. (`setup.py`, [setup.pyR22-R105](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R22-R105))

* **Support for universal2 binaries on macOS:**
  - Added logic to build `libpostal.a` for both `x86_64` and `arm64` architectures on macOS and combine them into a universal2 binary using `lipo`. Diagnostics were added to verify the resulting binary. (`setup.py`, [setup.pyR250-R296](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R250-R296))

### Diagnostics and debugging enhancements:

* **Post-build diagnostics:**
  - Added detailed post-build checks to verify the presence of `libpostal.a` and `.so` files, print linker flags, and inspect shared object dependencies (e.g., using `otool` on macOS). (`setup.py`, [setup.pyR330-R352](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R330-R352))

### CI workflow updates:

* **Streamlined Python version targeting:**
  - Limited the CI builds to the two latest CPython versions (3.11 and 3.12) by setting the `CIBW_BUILD` environment variable. (`.github/workflows/build_wheels.yml`, [.github/workflows/build_wheels.ymlR95-L131](diffhunk://#diff-52d0610b43ce35e44510ae2d15d70668334378b01c1bdc774159cd3a33b71728R95-L131))